### PR TITLE
Fixing compilation break and recognizing remote server's SMTPUTF8 capability

### DIFF
--- a/qmail-remote.c
+++ b/qmail-remote.c
@@ -534,77 +534,17 @@ int containsutf8(p, l) unsigned char * p; int l;
 
 int utf8message;
 
-void checkutf8message()
+int get_smtputf8_capa(const char *capa)
 {
-  int pos;
-  int i;
-  int r;
-  char ch;
-  int state;
-
-  if (containsutf8(sender.s, sender.len)) { utf8message = 1; return; }
-  for (i = 0;i < reciplist.len;++i)
-    if (containsutf8(reciplist.sa[i].s, reciplist.sa[i].len)) {
+  int i = 0, len;
+  len = str_len(capa);
+  for (i = 0; i < smtptext.len-len; ++i) {
+    if (case_starts(smtptext.s+i,capa)) {
       utf8message = 1;
-      return;
-    }
-
-  state = 0;
-  pos = 0;
-  for (;;) {
-    r = substdio_get(&ssin,&ch,1);
-    if (r == 0) break;
-    if (r == -1) temp_read();
-
-    if (ch == '\n' && !stralloc_cats(&firstpart,"\r")) temp_nomem();
-    if (!stralloc_append(&firstpart,&ch)) temp_nomem();
-
-    if (ch == '\r')
-      continue;
-    if (ch == '\t')
-      ch = ' ';
-
-    switch (state) {
-    case 6: /* in Received, at LF but before WITH clause */
-      if (ch == ' ') { state = 3; pos = 1; continue; }
-      state = 0;
-      /* FALL THROUGH */
-
-    case 0: /* start of header field */
-      if (ch == '\n') return;
-      state = 1;
-      pos = 0;
-      /* FALL THROUGH */
-
-    case 1: /* partway through "Received:" */
-      if (ch != "RECEIVED:"[pos] && ch != "received:"[pos]) { state = 2; continue; }
-      if (++pos == 9) { state = 3; pos = 0; }
-      continue;
-
-    case 2: /* other header field */
-      if (ch == '\n') state = 0;
-      continue;
-
-    case 3: /* in Received, before WITH clause or partway though " with " */
-      if (ch == '\n') { state = 6; continue; }
-      if (ch != " WITH "[pos] && ch != " with "[pos]) { pos = 0; continue; }
-      if (++pos == 6) { state = 4; pos = 0; }
-      continue;
-
-    case 4: /* in Received, having seen with, before the argument */
-      if (pos == 0 && (ch == ' ' || ch == '\t')) continue;
-      if (ch != "UTF8"[pos] && ch != "utf8"[pos]) { state = 5; continue; }
-      if(++pos == 4) { utf8message = 1; state = 5; continue; }
-      continue;
-
-    case 5: /* after the RECEIVED WITH argument */
-      /* blast() assumes that it copies whole lines */
-      if (ch == '\n') return;
-      state = 1;
-      pos = 0;
-      continue;
+      return 1;
     }
   }
+  return 0;
 }
 
 void smtp()
@@ -659,9 +599,8 @@ void smtp()
 #ifdef EHLO
   }
 #endif
- 
-  checkutf8message();
-  if (utf8message) quit("DConnected to "," but server does not support unicode in email addresses");
+
+  if (!get_smtputf8_capa("SMTPUTF8")) quit("DConnected to "," but server does not support unicode in email addresses");
 
   substdio_puts(&smtpto,"MAIL FROM:<");
   substdio_put(&smtpto,sender.s,sender.len);

--- a/qmail-remote.c
+++ b/qmail-remote.c
@@ -661,7 +661,7 @@ void smtp()
 #endif
  
   checkutf8message();
-  if (utf8message && !smtputf8) quit("DConnected to "," but server does not support unicode in email addresses");
+  if (utf8message) quit("DConnected to "," but server does not support unicode in email addresses");
 
   substdio_puts(&smtpto,"MAIL FROM:<");
   substdio_put(&smtpto,sender.s,sender.len);

--- a/qmail-remote.c
+++ b/qmail-remote.c
@@ -534,15 +534,91 @@ int containsutf8(p, l) unsigned char * p; int l;
 
 int utf8message;
 
-int get_smtputf8_capa(const char *capa)
+void checkutf8message()
+{
+  int pos;
+  int i;
+  int r;
+  char ch;
+  int state;
+
+  if (containsutf8(sender.s, sender.len)) { utf8message = 1; return; }
+  for (i = 0;i < reciplist.len;++i)
+    if (containsutf8(reciplist.sa[i].s, reciplist.sa[i].len)) {
+      utf8message = 1;
+      return;
+    }
+
+  state = 0;
+  pos = 0;
+  for (;;) {
+    r = substdio_get(&ssin,&ch,1);
+    if (r == 0) break;
+    if (r == -1) temp_read();
+
+    if (ch == '\n' && !stralloc_cats(&firstpart,"\r")) temp_nomem();
+    if (!stralloc_append(&firstpart,&ch)) temp_nomem();
+
+    if (ch == '\r')
+      continue;
+    if (ch == '\t')
+      ch = ' ';
+
+    switch (state) {
+    case 6: /* in Received, at LF but before WITH clause */
+      if (ch == ' ') { state = 3; pos = 1; continue; }
+      state = 0;
+      /* FALL THROUGH */
+
+    case 0: /* start of header field */
+      if (ch == '\n') return;
+      state = 1;
+      pos = 0;
+      /* FALL THROUGH */
+
+    case 1: /* partway through "Received:" */
+      if (ch != "RECEIVED:"[pos] && ch != "received:"[pos]) { state = 2; continue; }
+      if (++pos == 9) { state = 3; pos = 0; }
+      continue;
+
+    case 2: /* other header field */
+      if (ch == '\n') state = 0;
+      continue;
+
+    case 3: /* in Received, before WITH clause or partway though " with " */
+      if (ch == '\n') { state = 6; continue; }
+      if (ch != " WITH "[pos] && ch != " with "[pos]) { pos = 0; continue; }
+      if (++pos == 6) { state = 4; pos = 0; }
+      continue;
+
+    case 4: /* in Received, having seen with, before the argument */
+      if (pos == 0 && (ch == ' ' || ch == '\t')) continue;
+      if (ch != "UTF8"[pos] && ch != "utf8"[pos]) { state = 5; continue; }
+      if(++pos == 4) { utf8message = 1; state = 5; continue; }
+      continue;
+
+    case 5: /* after the RECEIVED WITH argument */
+      /* blast() assumes that it copies whole lines */
+      if (ch == '\n') return;
+      state = 1;
+      pos = 0;
+      continue;
+    }
+  }
+}
+
+/*
+  returns 1 if the remote server advertises a specific verb
+  tx notqmail/mbhangui-smtputf8
+ */
+int get_capa(const char *capa)
 {
   int i = 0, len;
   len = str_len(capa);
+  extern stralloc smtptext;
+
   for (i = 0; i < smtptext.len-len; ++i) {
-    if (case_starts(smtptext.s+i,capa)) {
-      utf8message = 1;
-      return 1;
-    }
+    if (case_starts(smtptext.s+i,capa)) return 1;
   }
   return 0;
 }
@@ -599,8 +675,9 @@ void smtp()
 #ifdef EHLO
   }
 #endif
-
-  if (!get_smtputf8_capa("SMTPUTF8")) quit("DConnected to "," but server does not support unicode in email addresses");
+ 
+  checkutf8message();
+  if (utf8message && !get_capa("SMTPUTF8")) quit("DConnected to "," but server does not support unicode in email addresses");
 
   substdio_puts(&smtpto,"MAIL FROM:<");
   substdio_put(&smtpto,sender.s,sender.len);


### PR DESCRIPTION
This PR fixes the following issues in smtputf8-tls branch:

- compilation break due to a missing smtputf8 declaration
- failure in recognizing the SMTPUTF8 verb on remote server

